### PR TITLE
ENH: Copy access security files to install location

### DIFF
--- a/ess.Makefile
+++ b/ess.Makefile
@@ -26,10 +26,9 @@ where_am_I := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 include $(E3_REQUIRE_TOOLS)/driver.makefile
 include $(E3_REQUIRE_CONFIG)/DECOUPLE_FLAGS
 
-
+SCRIPTS += $(wildcard ../template/*.asg)
 
 SCRIPTS +=$(wildcard ../iocsh/*.iocsh)
-
 
 
 db:
@@ -37,5 +36,4 @@ db:
 vlibs:
 
 .PHONY: db vlibs
-
 


### PR DESCRIPTION
Add .asg files to SCRIPTS target so that they get installed to the E3 build location.

Without this, the .asg files have to be accessed from a clone of this repo in an arbitrary location. I think it is better to have them available in a standard place.